### PR TITLE
Replace command check with 1.10 style to avoid null pointer crashes

### DIFF
--- a/src/main/java/gaia/util/Gaia_Commands.java
+++ b/src/main/java/gaia/util/Gaia_Commands.java
@@ -42,6 +42,8 @@ public class Gaia_Commands implements ICommand{
 
 	private final List aliases;
 
+    private static final int PERMISSION_LEVEL = 4;
+
 	public Gaia_Commands() 
 	{ 
 		aliases = new ArrayList(); 
@@ -394,9 +396,7 @@ public class Gaia_Commands implements ICommand{
 	//~~~~~~~~~~~~~~~~~~~~~~~~~~Required stuff ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 	@Override
 	public boolean checkPermission(MinecraftServer server, ICommandSender sender) {
-		EntityPlayer player = (EntityPlayer) sender.getCommandSenderEntity();
-
-		return player.isCreative();
+		return sender.canCommandSenderUseCommand(PERMISSION_LEVEL, this.getCommandName());
 	}
 
 	@Override


### PR DESCRIPTION
This patch fixes the "help" command when it is entered from the dedicated server console.