### PR TITLE
Inherent sounds fix

### DIFF
--- a/src/main/java/gaia/entity/monster/EntityGaiaMandragora.java
+++ b/src/main/java/gaia/entity/monster/EntityGaiaMandragora.java
@@ -166,17 +166,17 @@ public class EntityGaiaMandragora extends EntityMobHostileDay {
 
 	@Override
 	protected SoundEvent getAmbientSound() {
-		return Sounds.MUMMY_SAY;
+		return Sounds.MANDRAGORA_SAY;
 	}
 
 	@Override
 	protected SoundEvent getHurtSound(DamageSource damageSourceIn) {
-		return Sounds.MUMMY_HURT;
+		return Sounds.MANDRAGORA_HURT;
 	}
 
 	@Override
 	protected SoundEvent getDeathSound() {
-		return Sounds.MUMMY_DEATH;
+		return Sounds.MANDRAGORA_DEATH;
 	}
 
 	@Override

--- a/src/main/java/gaia/entity/monster/EntityGaiaMatango.java
+++ b/src/main/java/gaia/entity/monster/EntityGaiaMatango.java
@@ -213,17 +213,17 @@ public class EntityGaiaMatango extends EntityMobHostileDay {
 
 	@Override
 	protected SoundEvent getAmbientSound() {
-		return Sounds.MANDRAGORA_SAY;
+		return Sounds.MATANGO_SAY;
 	}
 
 	@Override
 	protected SoundEvent getHurtSound(DamageSource damageSourceIn) {
-		return Sounds.MANDRAGORA_HURT;
+		return Sounds.MATANGO_HURT;
 	}
 
 	@Override
 	protected SoundEvent getDeathSound() {
-		return Sounds.MANDRAGORA_DEATH;
+		return Sounds.MATANGO_DEATH;
 	}
 
 	@Override

--- a/src/main/java/gaia/entity/monster/EntityGaiaNaga.java
+++ b/src/main/java/gaia/entity/monster/EntityGaiaNaga.java
@@ -6,6 +6,7 @@ import gaia.GaiaConfig;
 import gaia.entity.EntityAttributes;
 import gaia.entity.EntityMobHostileDay;
 import gaia.init.GaiaItems;
+import gaia.init.Sounds;
 import gaia.items.ItemShard;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -27,6 +28,7 @@ import net.minecraft.pathfinding.PathNodeType;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EntityDamageSourceIndirect;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
@@ -186,6 +188,21 @@ public class EntityGaiaNaga extends EntityMobHostileDay {
 	private void setBuff() {
 		world.setEntityState(this, (byte) 7);
 		addPotionEffect(new PotionEffect(MobEffects.SPEED, 20 * 60, 0));
+	}
+	
+	@Override
+	protected SoundEvent getAmbientSound() {
+		return Sounds.NAGA_SAY;
+	}
+
+	@Override
+	protected SoundEvent getHurtSound(DamageSource damageSourceIn) {
+		return Sounds.NAGA_HURT;
+	}
+
+	@Override
+	protected SoundEvent getDeathSound() {
+		return Sounds.NAGA_DEATH;
 	}
 
 	@Override

--- a/src/main/java/gaia/entity/monster/EntityGaiaSharko.java
+++ b/src/main/java/gaia/entity/monster/EntityGaiaSharko.java
@@ -6,6 +6,7 @@ import gaia.GaiaConfig;
 import gaia.entity.EntityAttributes;
 import gaia.entity.EntityMobHostileBase;
 import gaia.init.GaiaItems;
+import gaia.init.Sounds;
 import gaia.items.ItemShard;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -26,6 +27,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.pathfinding.PathNodeType;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
@@ -180,6 +182,21 @@ public class EntityGaiaSharko extends EntityMobHostileBase {
 	private void setBuff() {
 		world.setEntityState(this, (byte) 7);
 		addPotionEffect(new PotionEffect(MobEffects.SPEED, 20 * 60, 0));
+	}
+	
+	@Override
+	protected SoundEvent getAmbientSound() {
+		return Sounds.SHARKO_SAY;
+	}
+
+	@Override
+	protected SoundEvent getHurtSound(DamageSource damageSourceIn) {
+		return Sounds.SHARKO_HURT;
+	}
+
+	@Override
+	protected SoundEvent getDeathSound() {
+		return Sounds.SHARKO_DEATH;
 	}
 
 	@Override

--- a/src/main/java/gaia/entity/monster/EntityGaiaYeti.java
+++ b/src/main/java/gaia/entity/monster/EntityGaiaYeti.java
@@ -6,6 +6,7 @@ import gaia.GaiaConfig;
 import gaia.entity.EntityAttributes;
 import gaia.entity.EntityMobHostileBase;
 import gaia.init.GaiaItems;
+import gaia.init.Sounds;
 import gaia.items.ItemShard;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -27,6 +28,7 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
@@ -115,6 +117,21 @@ public class EntityGaiaYeti extends EntityMobHostileBase {
 		}
 
 		super.onLivingUpdate();
+	}
+	
+	@Override
+	protected SoundEvent getAmbientSound() {
+		return Sounds.YETI_SAY;
+	}
+
+	@Override
+	protected SoundEvent getHurtSound(DamageSource damageSourceIn) {
+		return Sounds.YETI_HURT;
+	}
+
+	@Override
+	protected SoundEvent getDeathSound() {
+		return Sounds.YETI_DEATH;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes the Matango and Madragora referencing incorrect sound.json entries. Whoopsie.
Also adds sound.json references to 3 creatures that didn't have any: Sharko, Naga and Yeti.