### PR TITLE
1.21 - Improve tooltips

### DIFF
--- a/src/main/java/gaia/config/GaiaConfig.java
+++ b/src/main/java/gaia/config/GaiaConfig.java
@@ -11,6 +11,8 @@ import org.apache.commons.lang3.tuple.Pair;
 public class GaiaConfig {
 	public static class Client {
 		public final BooleanValue genderNeutral;
+		public final BooleanValue hideFoodEffectTooltips;
+		public final BooleanValue hideFoodXpTooltips;
 
 		Client(ModConfigSpec.Builder builder) {
 			builder.comment("Client settings")
@@ -19,6 +21,14 @@ public class GaiaConfig {
 			genderNeutral = builder
 					.comment("When enabled makes the mobs look more gender neutral (default: false)")
 					.define("genderNeutral", false);
+
+			hideFoodEffectTooltips = builder
+					.comment("When enabled effect tooltips on edible items will be hidden (default: false)")
+					.define("hideFoodEffectTooltips", false);
+
+			hideFoodXpTooltips = builder
+					.comment("When enabled effect tooltips on edible items will be hidden (default: false)")
+					.define("hideFoodEffectTooltips", false);
 
 			builder.pop();
 		}

--- a/src/main/java/gaia/item/ExperienceItem.java
+++ b/src/main/java/gaia/item/ExperienceItem.java
@@ -51,7 +51,7 @@ public class ExperienceItem extends Item {
 	@Override
 	public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(stack, context, list, flag);
-		if (levels > 1) {
+		if (levels == 1) {
 			list.add(Component.translatable("text.grimoireofgaia.gain_level", levels).withStyle(ChatFormatting.GRAY));
 		} else {
 			list.add(Component.translatable("text.grimoireofgaia.gain_levels", levels).withStyle(ChatFormatting.GRAY));

--- a/src/main/java/gaia/item/edible/EdibleEffectItem.java
+++ b/src/main/java/gaia/item/edible/EdibleEffectItem.java
@@ -1,5 +1,6 @@
 package gaia.item.edible;
 
+import gaia.config.GaiaConfig;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -22,13 +23,14 @@ public class EdibleEffectItem extends Item {
 	public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(stack, context, list, flag);
 		FoodProperties foodProperties = stack.getFoodProperties(null);
-		if (foodProperties != null) {
+		if (foodProperties != null && !GaiaConfig.CLIENT.hideFoodEffectTooltips.getAsBoolean()) {
 			for (FoodProperties.PossibleEffect possibleEffect : foodProperties.effects()) {
 				MobEffectInstance effect = possibleEffect.effect();
 				int totalSeconds = effect.getDuration() / 20;
 				int minutes = (totalSeconds % 3600) / 60;
 				int seconds = totalSeconds % 60;
-				list.add(Component.translatable(effect.getDescriptionId()).append(Component.literal(" (" + minutes + ":" + seconds + ")")).withStyle(ChatFormatting.GRAY));
+				String formattedSeconds = seconds <= 9 ? "0" + String.valueOf(seconds) : String.valueOf(seconds);
+				list.add(Component.translatable(effect.getDescriptionId()).append(Component.literal(" (" + minutes + ":" + formattedSeconds + ")")).withStyle(ChatFormatting.GRAY));
 			}
 		}
 	}

--- a/src/main/java/gaia/item/edible/EdibleEffectItem.java
+++ b/src/main/java/gaia/item/edible/EdibleEffectItem.java
@@ -29,8 +29,7 @@ public class EdibleEffectItem extends Item {
 				int totalSeconds = effect.getDuration() / 20;
 				int minutes = (totalSeconds % 3600) / 60;
 				int seconds = totalSeconds % 60;
-				String formattedSeconds = seconds <= 9 ? "0" + String.valueOf(seconds) : String.valueOf(seconds);
-				list.add(Component.translatable(effect.getDescriptionId()).append(Component.literal(" (" + minutes + ":" + formattedSeconds + ")")).withStyle(ChatFormatting.GRAY));
+				list.add(Component.translatable(effect.getDescriptionId()).append(Component.literal(String.format(" (%d:%02d)", minutes, seconds))).withStyle(ChatFormatting.GRAY));
 			}
 		}
 	}

--- a/src/main/java/gaia/item/edible/XPEdibleItem.java
+++ b/src/main/java/gaia/item/edible/XPEdibleItem.java
@@ -1,5 +1,6 @@
 package gaia.item.edible;
 
+import gaia.config.GaiaConfig;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.LivingEntity;
@@ -22,7 +23,9 @@ public class XPEdibleItem extends EdibleEffectItem {
 	@Override
 	public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> list, TooltipFlag flag) {
 		super.appendHoverText(stack, context, list, flag);
-		list.add(Component.translatable("text.grimoireofgaia.gain_experience"));
+		if(!GaiaConfig.CLIENT.hideFoodXpTooltips.getAsBoolean()){
+			list.add(Component.translatable("text.grimoireofgaia.gain_experience"));
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Fixes a problem with effect tooltips. Now it properly shows like M:SS, whereas before it would show M:S, making it harder to read / not obvious that it's a timer if the seconds part was one digit.

Before:
![image](https://github.com/user-attachments/assets/e3b107aa-54f0-4443-a21e-d0bf5927423f)
After:
![image](https://github.com/user-attachments/assets/c9da292a-1f39-428a-99d2-0b9ba806589a)

Also adds client config options to disable effect and experience tooltips (Effect Descriptions by Fuzs already does the former) 